### PR TITLE
Enable referenceablebehavior on lists and memberships.

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -5,7 +5,8 @@ Changelog
 0.29 (unreleased)
 ~~~~~~~~~~~~~~~~~
 
-Nothing yet.
+- Enable referenceablebehavior on lists and memberships.
+  [jone]
 
 0.28 (2015-03-02)
 ~~~~~~~~~~~~~~~~~

--- a/seantis/people/profiles/default/metadata.xml
+++ b/seantis/people/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>1010</version>
+    <version>1011</version>
     <dependencies>
         <dependency>profile-plone.app.dexterity:default</dependency>
         <dependency>profile-collective.js.underscore:default</dependency>

--- a/seantis/people/profiles/default/types/seantis.people.list.xml
+++ b/seantis/people/profiles/default/types/seantis.people.list.xml
@@ -22,6 +22,7 @@
   <!-- enabled behaviors -->
   <property name="behaviors">
     <element value="plone.app.content.interfaces.INameFromTitle" />
+    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
   </property>
 
   <!-- actions -->

--- a/seantis/people/profiles/default/types/seantis.people.membership.xml
+++ b/seantis/people/profiles/default/types/seantis.people.membership.xml
@@ -22,6 +22,7 @@
   <!-- enabled behaviors -->
   <property name="behaviors">
     <element value="seantis.plonetools.behaviors.customtitle.ICustomTitle" />
+    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
   </property>
 
 </object>

--- a/seantis/people/upgrades.py
+++ b/seantis/people/upgrades.py
@@ -98,3 +98,18 @@ def reindex_selectable_fields(context):
     catalog = api.portal.get_tool(catalog_id)
     catalog.manage_catalogClear()
     catalog.manage_catalogRebuild()
+
+
+def enable_referenceablebehavior(context):
+    catalog = api.portal.get_tool('portal_catalog')
+    uid_catalog = api.portal.get_tool('uid_catalog')
+    types = api.portal.get_tool('portal_types')
+    portal = api.portal.get()
+
+    for type_name in ('seantis.people.list', 'seantis.people.membership'):
+        types[type_name].behaviors += (
+            'plone.app.referenceablebehavior.referenceable.IReferenceable',)
+
+        for brain in catalog.unrestrictedSearchResults(portal_type=type_name):
+            obj = portal.unrestrictedTraverse(brain.getPath())
+            uid_catalog.catalog_object(obj, brain.getPath())

--- a/seantis/people/upgrades.zcml
+++ b/seantis/people/upgrades.zcml
@@ -72,6 +72,13 @@
         handler=".upgrades.reindex_selectable_fields"
     />
 
+    <genericsetup:upgradeStep
+        title="Enable referenceablebehavior."
+        source="1010" destination="1011"
+        profile="seantis.people:default"
+        handler=".upgrades.enable_referenceablebehavior"
+    />
+
     <!-- PHZ Upgrades -->
     <genericsetup:upgradeStep
         title="Remove import action from detail view."

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'five.grok',
         'plone.behavior',
         'plone.app.dexterity [grok, relations]',
+        'plone.app.referenceablebehavior',
         'plone.app.registry',
         'plone.formwidget.datetime',
         'seantis.plonetools>=0.16',


### PR DESCRIPTION
The referenceablebehavior allows to add references from Archetypes objects to Dexterity objects.
It also adds the UIDs of the Dexterity objects to the UID catalog so that it can be queried for getting the object.

We need this for displaying recent changes on a dashboard of a remote Plone site using [ftw.bridge.client](https://github.com/4teamwork/ftw.bridge.client), which is based on UID lookups.